### PR TITLE
LCGP: VNNGP-style parameterization, installer, and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,81 @@
+# GPzoo Development Notes
+
+## Project Overview
+
+GPzoo is a pip-installable PyTorch library of Gaussian Process building blocks for spatial transcriptomics. It is used as a **dependency by two downstream libraries**:
+
+- **[PNMF](https://github.com/luisdiaz1997/Probabilistic-NMF)** — Probabilistic NMF with GP spatial priors
+- **[Spatial-Factorization](https://github.com/luisdiaz1997/Spatial-Factorization)** — End-to-end spatial transcriptomics pipeline
+
+## Installation
+
+```bash
+pip install git+https://github.com/luisdiaz1997/GPzoo.git
+```
+
+Or in editable mode for development:
+```bash
+pip install -e .
+```
+
+All metadata and dependencies live in `pyproject.toml`. `setup.py` is a minimal stub for backwards compatibility only.
+
+## Package Structure
+
+Only the top-level files in `gpzoo/` are part of the installed package (subfolders are not included):
+
+```
+gpzoo/
+├── __init__.py          # Public API: SVGP_NSF, VNNGP_NSF, MGGP_SVGP_NSF, MGGP_VNNGP_NSF, build_model
+├── gp.py                # Core GP classes: SVGP, VNNGP, LCGP, MGGP_SVGP, MGGP_VNNGP, MGGP_LCGP, GaussianPrior
+├── kernels.py           # Kernel functions: batched_Matern32, batched_MGGP_Matern32, batched_MGGP_RBF, etc.
+├── likelihoods.py       # Likelihood models: NSF2, GaussianLikelihood
+├── model_utilities.py   # Utilities: kmeans_inducing_points(), mggp_kmeans_inducing_points()
+├── modules.py           # Parameter classes: PositiveParameter, CholeskyParameter
+├── natural_gradient.py  # NaturalGradientDescent optimizer
+├── training_utilities.py# Training helpers
+└── utilities.py         # Math utilities: add_jitter, svgp_forward, whitened_KL, calculate_knn, etc.
+```
+
+## Key Components Consumed by PNMF
+
+| Component | File | Used for |
+|-----------|------|----------|
+| `PositiveParameter`, `CholeskyParameter` | `modules.py` | Constrained parameters |
+| `GaussianPrior` | `gp.py` | Non-spatial variational prior |
+| `SVGP`, `MGGP_SVGP` | `gp.py` | Sparse GP prior (N < 10k) |
+| `LCGP`, `MGGP_LCGP` | `gp.py` | Locally conditioned GP prior (N > 10k) |
+| `batched_Matern32`, `batched_MGGP_Matern32` | `kernels.py` | Kernel functions |
+| `kmeans_inducing_points()`, `mggp_kmeans_inducing_points()` | `model_utilities.py` | Inducing point selection |
+
+## GP Model Hierarchy
+
+```
+SVGP  (sparse variational GP, M << N, full Cholesky)
+  └── MGGP_SVGP  (multi-group variant, batched_MGGP_Matern32 kernel)
+  └── LCGP       (M = N, VNNGP-style S = Lu @ Lu.T, locally conditioned KL)
+        └── MGGP_LCGP  (multi-group LCGP)
+VNNGP  (nearest-neighbor GP, separate from SVGP hierarchy)
+  └── MGGP_VNNGP
+```
+
+## LCGP Parameterization
+
+LCGP uses the **same parameterization as VNNGP**: `Lu` is a raw `nn.Parameter(L, M, K)` and `S = Lu @ Lu.T`. Key overrides vs SVGP:
+- `apply_constraints()` — returns `(mu, Lu)` directly (no Cholesky constraint)
+- `reshape_parameters()` — indexes Lu by KNN, computes `S = Lu_knn @ Lu_knn.T`, Cholesky-factors them
+- `kl_divergence_full()` — locally conditioned KL using VNNGP's whitened formulation
+- KNN convention: training uses `knn_idz = calculate_knn(Z)[:, 1:]`, inference uses `knn_idx = calculate_knn(X)[:, :-1]`
+
+## Dependencies
+
+- `torch>=1.9.0`
+- `numpy>=1.19.0`
+- `scikit-learn>=1.0.0` (KMeans, NMF, KNeighbors)
+- `tqdm>=4.0.0`
+- `faiss-cpu>=1.7.0` (KNN computation via `calculate_knn`)
+- `matplotlib>=3.3.0`
+
+## Development Workflow
+
+Every new plan or significant feature gets its own git branch. `PLAN.md` lives on the feature branch, not on main.

--- a/gpzoo/gp.py
+++ b/gpzoo/gp.py
@@ -3,7 +3,7 @@ from torch import distributions
 from torch.distributions import constraints, transform_to
 import torch.nn as nn
 from .utilities import add_jitter, svgp_forward, reshape_param, whitened_KL, is_lower_triangular
-from .modules import CholeskyParameter, LowRankPlusDiagonal
+from .modules import CholeskyParameter
 import faiss
 
 
@@ -743,30 +743,32 @@ class VNNGP(SVGP):
         
 class LCGP(SVGP):
     """
-    Locally Conditioned GP using low-rank plus diagonal variational covariance.
-    
+    Locally Conditioned GP using the same S = Lu Lu^T parameterization as VNNGP.
+
     Uses the locally conditioned KL approximation:
         KL(q(U) || p(U)) ≈ Σ_j E_{q(U_{n(j)})}[KL(q(U_j|U_{n(j)}) || p(U_j|U_{n(j)}))]
-    
-    Variational covariance S = D + VV^T parameterized via LowRankPlusDiagonal,
-    giving O(MR) parameters instead of O(M²).
-    
+
+    Lu is a raw nn.Parameter of shape (M, K) (or (L, M, K) for batched).
+    S = Lu @ Lu^T gives the variational covariance.
+
     For NSF models with L factors, the parameters are batched:
     - mu: (L, M)
-    - S = D + VV^T where D: (L, M), V: (L, M, R)
+    - Lu: (L, M, K)
     """
-    
+
     def __init__(self, kernel, dim=1, M=50, jitter=1e-4, K=3, rank=None, diag_mode='softplus'):
+        # Call SVGP parent (which creates Lu as CholeskyParameter)
         super().__init__(kernel, dim, M, jitter, diagonal_only=True, cholesky_mode='exp')
-        
+
         self.K = K
         self.knn_idx = None
         self.knn_idz = None
-        
+        self.inducing_points = True
+
+        # Override Lu with a raw nn.Parameter (same as VNNGP)
         del self.Lu
-        rank = rank if rank is not None else min(M, K + 5)
-        self.Lu = LowRankPlusDiagonal(m=M, rank=rank, batch_size=None, diag_mode=diag_mode)
-    
+        self.Lu = nn.Parameter(torch.randn((M, K)))
+
     def calculate_knn(self, X):
         """Calculate the K+1 nearest neighbors of X in Z using FAISS."""
         X_np = X.detach().cpu().float().numpy()
@@ -774,8 +776,8 @@ class LCGP(SVGP):
         index = faiss.IndexFlatL2(Z.shape[-1])
         index.add(Z)
         distances, indices = index.search(X_np, self.K + 1)
-        return torch.tensor(indices, dtype=torch.long, device=X.device)
-    
+        return torch.tensor(indices, dtype=torch.long, device='cpu')
+
     def reshape_input_data(self, **kwargs):
         """Same as VNNGP - reshape for local kernel computation."""
         X = kwargs.get("X")
@@ -785,34 +787,56 @@ class LCGP(SVGP):
         X, Z = super(SVGP, self).reshape_input_data(X=X, Z=Z)
         X = X.unsqueeze(-2)  # (N, 1, D)
         Z = Z[knn_idx]       # (N, K, D)
-        
+
         return X, Z
 
     def apply_constraints(self):
-        # LCGP: Lu is LowRankPlusDiagonal, not a simple tensor.
-        # Return None for Lu — reshape_parameters builds local Cholesky from get_block().
-        return self.mu, None
+        mu = self.mu
+        Lu = self.Lu
+        return mu, Lu
 
     def reshape_parameters(self, mu, Lu, covariances, verbose=False, knn_idx=None):
+        """Reshape parameters for local GP computation (copied from VNNGP)."""
         if knn_idx is None:
             knn_idx = self.knn_idx
 
         Kxx, Kzx, Kzz = covariances
-        Kzz = add_jitter(Kzz, self.jitter)
 
-        # Slice mu by KNN (same as VNNGP)
-        mu_shape = mu.shape
-        mu_reshaped = mu.reshape(-1, mu_shape[-1])
-        mu_knn = mu_reshaped[..., knn_idx]
+        if verbose:
+            print('adding jitter to Kzz')
+        Kzz = add_jitter(Kzz, self.jitter)
+        if verbose:
+            print('done with jitter')
+        mu_shape = mu.shape  # e.g., [*B, M]
+        mu_reshaped = mu.reshape(-1, mu_shape[-1])  # [B, M]
+
+        # knn_idx: [N, K] to index M
+        mu_knn = mu_reshaped[..., knn_idx]  # [B, N, K]
         mu = mu_knn.reshape(*mu_shape[:-1], knn_idx.shape[0], self.K)
 
-        # Get local K×K covariance blocks from LowRankPlusDiagonal
-        # S_block[n] = diag(D[knn[n]]) + V[knn[n]] @ V[knn[n]].T
-        Su_knn = self.Lu.get_block(knn_idx)  # (L, N, K, K) or (N, K, K)
+        Lu_shape = Lu.shape  # [*B, M, K]
+        Lu_reshaped = Lu.reshape(-1, Lu_shape[-2], Lu_shape[-1])  # [B, M, K]
+        Lu_knn = Lu_reshaped[:, knn_idx]  # [B, N, K, K]
+
+        Su_knn = Lu_knn @ Lu_knn.transpose(-2, -1)  # [B, N, K, K]
+        Su_knn = Su_knn.reshape(*Lu_shape[:-2], knn_idx.shape[0], self.K, self.K)
+
         Su_knn = add_jitter(Su_knn, self.jitter)
-        Lu = torch.linalg.cholesky(Su_knn)   # Local Cholesky factors
+        Lu = torch.linalg.cholesky(Su_knn)  # [*B, N, K, K]
+
+        if verbose:
+            print('Lu_knn shape:', Lu_knn.shape)
+            print('Lu.shape:', Lu.shape)
 
         Kxx = Kxx.squeeze(-1)
+
+        if verbose:
+            print('Reshaped mu:', mu.shape)
+            print('Reshaped Lu:', Lu.shape)
+            print('Reshaped Kzx:', Kzx.shape)
+            print('Reshaped Kzz:', Kzz.shape)
+            print('Reshaped Kxx:', Kxx.shape)
+
         return mu, Lu, Kxx, Kzx, Kzz
 
     def forward(self, X, diag=True, verbose=False, **kwargs):
@@ -822,140 +846,97 @@ class LCGP(SVGP):
 
     def forward_train(self, X, idx=None, diag=True, verbose=False, **kwargs):
         """Training forward - marginal q(U_j) = N(m_j, s_jj).
-        
-        For the batched case (L factors):
-            mu: (L, M) -> mu_batch: (L, batch_size)
-            s_jj: (L, batch_size)
-        
-        Args:
-            X: Input points (not directly used, kept for API compatibility)
-            idx: Indices of points in the minibatch (into M dimension)
-            diag: Whether to return diagonal covariance
-            verbose: Print debug info
-            **kwargs: Additional arguments (e.g., groupsX for MGGP)
-        
-        Returns:
-            qF: Normal distribution N(mu_batch, sqrt(s_jj))
-            None, None: Placeholders for qZ, pZ
+
+        s_jj = sum(Lu_j**2) since S = Lu Lu^T and diagonal is sum of squares.
         """
-        mu = self.mu  # Shape: (L, M) or (M,)
-        D = self.Lu.D  # Shape: (L, M) or (M,)
-        V = self.Lu.V.data  # Shape: (L, M, R) or (M, R)
-        
-        # Determine if we're in batched mode (L factors)
-        is_batched = mu.dim() == 2
-        
         if idx is not None:
-            if is_batched:
-                # Batched case: shapes are (L, M, ...)
-                mu_batch = mu[:, idx]  # (L, M) -> (L, batch_size)
-                D_batch = D[:, idx]    # (L, M) -> (L, batch_size)
-                V_batch = V[:, idx]    # (L, M, R) -> (L, batch_size, R)
-            else:
-                # Unbatched case: shapes are (M, ...)
-                mu_batch = mu[idx]     # (M,) -> (batch_size,)
-                D_batch = D[idx]       # (M,) -> (batch_size,)
-                V_batch = V[idx]       # (M, R) -> (batch_size, R)
-            
-            s_diag = D_batch + (V_batch ** 2).sum(dim=-1)
+            mean = self.mu[:, idx]
+            cov = torch.sum(self.Lu[:, idx]**2, dim=-1)
         else:
-            mu_batch = mu
-            s_diag = D + (V ** 2).sum(dim=-1)
-        
-        s_diag = torch.clamp(s_diag, min=1e-6, max=100.0)
-        qF = distributions.Normal(mu_batch, s_diag.sqrt())
-        
+            mean = self.mu
+            cov = torch.sum(self.Lu**2, dim=-1)
+
+        cov = torch.clamp(cov, min=1e-3, max=100.0)
+        scale = cov**0.5
+
+        qF = distributions.Normal(mean, scale)
         return qF, None, None
-    
+
     def kl_divergence_full(self, qZ=None, pZ=None, verbose=False, idx=None, **kwargs):
         """
-        Locally conditioned KL divergence (unsimplified form).
+        Locally conditioned KL divergence (copied from VNNGP).
         """
-        # Setup indices
         if idx is not None:
+            idx_cpu = idx.cpu() if idx.device.type != 'cpu' else idx
             Z = self.Z[idx]
-            knn_idx = self.knn_idz[idx]
-            idx_tensor = idx
+            if hasattr(self, 'groupsZ'):
+                groupsZ = self.groupsZ[idx]
+            knn_idx = self.knn_idz[idx_cpu]
         else:
             Z = self.Z
+            if hasattr(self, 'groupsZ'):
+                groupsZ = self.groupsZ
             knn_idx = self.knn_idz
-            idx_tensor = torch.arange(Z.shape[0], device=Z.device)
-        
-        # Prior terms (kernel) - no L dimension
+
         if hasattr(self, 'groupsZ'):
-            groupsZ_batch = self.groupsZ[idx] if idx is not None else self.groupsZ
-            covariances = self.forward_kernels(X=Z, groupsX=groupsZ_batch, diag=True, knn_idx=knn_idx)
+            covariances = self.forward_kernels(X=Z, groupsX=groupsZ, diag=True, knn_idx=knn_idx)
         else:
             covariances = self.forward_kernels(X=Z, diag=True, knn_idx=knn_idx)
-        
-        Kxx, Kzx, Kzz = covariances
-        
-        # Kxx comes out as (M', 1) from reshape_input_data's X.unsqueeze(-2)
-        # Kzx comes out as (M', K, 1) - need to squeeze
-        # Kzz is (M', K, K)
-        k_jj = Kxx.squeeze(-1).squeeze(-1)  # (M', 1) -> (M',)
-        K_nj = Kzx.squeeze(-1)               # (M', K, 1) -> (M', K)
-        Kzz = add_jitter(Kzz, self.jitter)   # (M', K, K)
-        
-        # Cholesky and solve for β
-        L_prior = torch.linalg.cholesky(Kzz)
-        beta_t = torch.linalg.solve_triangular(L_prior, K_nj.unsqueeze(-1), upper=False)
-        
-        # τ_j² and β
-        tau_sq = torch.clamp(k_jj - (beta_t.squeeze(-1) ** 2).sum(dim=-1), min=1e-6)  # (M',)
-        beta = torch.linalg.solve_triangular(L_prior.transpose(-2, -1), beta_t, upper=True).squeeze(-1)  # (M', K)
-        
-        # Variational terms - has L dimension
-        mu = self.mu
-        is_batched = mu.dim() == 2
-        
-        # Get τ̃_j² and α_j
-        # D_inv, Psi_chol = self.Lu.get_precision_components()
-        # tau_tilde_sq, alpha = self.Lu.get_conditional_params(
-        #     knn_idx=knn_idx, D_inv=D_inv, Psi_cholesky=Psi_chol, idx=idx_tensor
-        # )
 
-    
-        tau_tilde_sq, alpha = self.Lu.get_conditional_params_exact(
-            knn_idx=knn_idx, idx=idx_tensor
-        )
-        
-        # Get S_{n(j)n(j)} and means
-        S_nn = self.Lu.get_block(knn_idx)
-        
-        if is_batched:
-            mu_j = mu[:, idx_tensor]
-            mu_neighbors = mu[:, knn_idx]
-            tau_sq = tau_sq.unsqueeze(0)  # (M',) -> (1, M')
-            beta = beta.unsqueeze(0)       # (M', K) -> (1, M', K)
+        mu, Lu = self.apply_constraints()
+
+        if idx is not None:
+            mu_diag = mu[:, idx]
+            Lu_diag = Lu[:, idx]
         else:
-            mu_j = mu[idx_tensor]
-            mu_neighbors = mu[knn_idx]
-        
-        # Mean difference
-        mean_diff = mu_j - (beta * mu_neighbors).sum(dim=-1)
-        
-        # Quadratic forms
-        beta_exp = beta.unsqueeze(-2)
-        alpha_exp = alpha.unsqueeze(-2)
-        
-        beta_S_beta = (beta_exp @ S_nn @ beta_exp.transpose(-2, -1)).squeeze(-1).squeeze(-1)
+            mu_diag = mu
+            Lu_diag = Lu
 
-        alpha_S_alpha = (alpha_exp @ S_nn @ alpha_exp.transpose(-2, -1)).squeeze(-1).squeeze(-1)
-        
-        alpha_S_beta = (alpha_exp @ S_nn @ beta_exp.transpose(-2, -1)).squeeze(-1).squeeze(-1)
-        
-        # KL (unsimplified form)
-        KL = 0.5 * (
-            torch.log(tau_sq) - torch.log(tau_tilde_sq) - 1
-            + tau_tilde_sq / tau_sq
-            + alpha_S_alpha / tau_sq
-            + (mean_diff ** 2) / tau_sq
-            + beta_S_beta / tau_sq
-            - 2 * alpha_S_beta / tau_sq
-        )
-        
-        return KL.sum()
+        mu_knn, Lu_knn, Kxx, Kzx, Kzz = self.reshape_parameters(mu, Lu, covariances, knn_idx=knn_idx, verbose=verbose)
+
+        L = torch.linalg.cholesky(Kzz)
+        Wt = torch.linalg.solve_triangular(L, Kzx, upper=False)
+        W = Wt.transpose(-2, -1)  # B x N x 1 x K
+        mu_tranformed, Lu_transfomed = self.transform_variables(mu_knn, Lu_knn, L, verbose=verbose)
+
+        Lu_knn_2 = Lu[:, knn_idx]  # B x N x K x K
+        S_knnj = Lu_knn_2 @ (Lu_diag.unsqueeze(-1))  # B x N x K x 1
+
+        W2t = torch.linalg.solve_triangular(Lu_knn, S_knnj, upper=False)  # B x N x K x 1
+        W2 = W2t.transpose(-2, -1)  # B x N x 1 x K
+        WLu = W @ Lu_transfomed  # B x N x 1 x K
+
+        abterm = torch.sum(W2 * WLu, dim=-1)
+
+        mean = W @ mu_tranformed.unsqueeze(-1)  # B x N x 1 x 1
+        mean = mean.squeeze(-1)  # B x N x 1
+
+        cov_diff = Kxx - torch.sum(W**2, dim=-1)  # B x N x 1
+        cov_diff = torch.clamp(cov_diff, min=1e-6, max=100.0)
+
+        mean_diff = mu_diag.unsqueeze(-1) - mean  # B x N x 1
+        cov_knn = torch.sum(WLu**2, dim=-1)
+
+        S_diag = torch.sum(Lu_diag**2, dim=-1).unsqueeze(-1)  # B x N x 1
+        S_term = torch.sum(W2**2, dim=-1)  # B x N x 1
+        S_diff = S_diag - S_term
+
+        S_diff = torch.clamp(S_diff, min=1e-6, max=100.0)
+
+        if verbose:
+            print('mean_diff shape:', mean_diff.shape)
+            print('cov_diff shape:', cov_diff.shape)
+            print('S_diag shape:', S_diag.shape)
+            print('S_term shape:', S_term.shape)
+            print('cov_knn shape:', cov_knn.shape)
+            print('abterm shape:', abterm.shape)
+            print('S_diff shape:', S_diff.shape)
+
+        KL = torch.log(cov_diff) - torch.log(S_diff) - 1 + (mean_diff**2 + S_diag + cov_knn - 2*abterm) / cov_diff
+
+        KL = 0.5 * KL
+
+        return torch.sum(KL)
 
 
 

--- a/gpzoo/model_utilities.py
+++ b/gpzoo/model_utilities.py
@@ -282,72 +282,76 @@ def mggp_kmeans_inducing_points(
         missing_groups = set(unique_groups) - set(derived_groups)
 
         if missing_groups:
-            # Fall back to proportional allocation for missing groups
             warnings.warn(
                 f"allocation='derived' failed to assign inducing points to groups "
-                f"{sorted(missing_groups)}. Falling back to 'proportional' allocation "
-                f"for these groups.",
+                f"{sorted(missing_groups)}. Sampling donor points to fill missing groups.",
                 UserWarning
             )
 
-            # Calculate how many points needed for missing groups (proportional)
-            missing_counts = group_counts[np.isin(unique_groups, list(missing_groups))]
-            missing_total = missing_counts.sum()
-            n_missing = len(missing_groups)
-            n_needed = min(
-                int(missing_total / total_available * total_points),
-                total_points // n_missing
-            )
-            n_needed = max(n_needed, 1)  # At least 1 per missing group
+            rng = np.random.default_rng(seed)
 
-            # Generate K-means for missing groups
-            fallback_centers_list = []
-            fallback_group_list = []
-            for g in missing_groups:
-                g_idx = np.where(unique_groups == g)[0][0]
-                mask = groups_np == g
-                count = mask.sum()
-                n_clusters = min(n_needed, count)
+            # Mutable work lists; positions here are stable indices (we never reorder).
+            # Positions 0..M-1 come from Z_derived; later positions are appended fallbacks.
+            Z_work = list(Z_derived)
+            G_work = list(groupsZ_derived.tolist())
 
-                if n_clusters > 0:
-                    kmeans_fb = KMeans(n_clusters=n_clusters, random_state=seed, n_init=n_init)
-                    kmeans_fb.fit(X_np[mask])
-                    fallback_centers_list.append(kmeans_fb.cluster_centers_)
-                    fallback_group_list.append(np.full(n_clusters, g, dtype=np.int64))
+            # group_to_pos[g] = set of currently-active positions for group g
+            group_to_pos = {}
+            for pos, g in enumerate(G_work):
+                group_to_pos.setdefault(int(g), set()).add(pos)
 
-            # Remove some derived points to make room for fallback points
-            n_replace = sum(len(g) for g in fallback_group_list)
-            if n_replace > 0:
-                # Remove points from groups that have excess (more than proportional share)
-                derived_group_counts = np.bincount(groupsZ_derived, minlength=len(unique_groups))
-                target_per_group = (total_points - n_replace) * group_counts / total_available
-                excess_mask = derived_group_counts > target_per_group
+            removed_pos = set()  # positions to exclude when reconstructing
 
-                remove_indices = []
-                for g_idx in np.where(excess_mask)[0]:
-                    g = unique_groups[g_idx]
-                    n_remove = int(derived_group_counts[g_idx] - target_per_group[g_idx])
-                    if n_remove > 0:
-                        g_indices = np.where(groupsZ_derived == g)[0]
-                        remove_indices.extend(g_indices[:n_remove])
+            # donor_threshold: a donor group must have strictly more than this many
+            # active points.  Start at 1 so donors always keep ≥ 1 point after giving.
+            donor_threshold = 1
 
-                # Remove excess derived points
-                if remove_indices:
-                    keep_mask = np.ones(len(Z_derived), dtype=bool)
-                    keep_mask[remove_indices] = False
-                    Z_derived = Z_derived[keep_mask]
-                    groupsZ_derived = groupsZ_derived[keep_mask]
+            for missing_g in sorted(missing_groups):
+                # Lower threshold until we can find at least one donor.
+                t = donor_threshold
+                while t >= 0:
+                    donors = [
+                        g for g, pos_set in group_to_pos.items()
+                        if len(pos_set) > t
+                    ]
+                    if donors:
+                        break
+                    t -= 1
 
-                # Concatenate fallback points
-                if fallback_centers_list:
-                    Z_derived = np.concatenate([
-                        Z_derived,
-                        np.concatenate(fallback_centers_list, axis=0)
-                    ], axis=0)
-                    groupsZ_derived = np.concatenate([
-                        groupsZ_derived,
-                        np.concatenate(fallback_group_list, axis=0)
-                    ], axis=0)
+                if not donors:
+                    warnings.warn(
+                        f"No donors available for group {missing_g}; "
+                        f"it will have no inducing points.",
+                        UserWarning
+                    )
+                    continue
+
+                n_donors = len(donors)
+
+                # Remove 1 point from each donor group (random choice).
+                for donor_g in donors:
+                    avail = list(group_to_pos[donor_g])
+                    pick = int(rng.integers(len(avail)))
+                    pos = avail[pick]
+                    removed_pos.add(pos)
+                    group_to_pos[donor_g].discard(pos)
+
+                # Sample n_donors data points from the missing group and append.
+                X_mg = X_np[groups_np == missing_g]
+                new_pts = X_mg[
+                    rng.choice(len(X_mg), size=n_donors, replace=(n_donors > len(X_mg)))
+                ]
+                start = len(Z_work)
+                Z_work.extend(new_pts)
+                G_work.extend([missing_g] * n_donors)
+                group_to_pos.setdefault(missing_g, set()).update(
+                    range(start, start + n_donors)
+                )
+
+            # Reconstruct: keep every position not in removed_pos.
+            keep = [i for i in range(len(Z_work)) if i not in removed_pos]
+            Z_derived = np.array([Z_work[i] for i in keep])
+            groupsZ_derived = np.array([G_work[i] for i in keep], dtype=groupsZ_derived.dtype)
 
         return (
             torch.tensor(Z_derived, dtype=X.dtype, device=X.device),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,56 @@
+[build-system]
+requires = ["setuptools>=45", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "gpzoo"
+version = "0.1.0"
+description = "Gaussian Process models for spatial transcriptomics"
+readme = "README.md"
+requires-python = ">=3.14"
+license = {text = "GPL-2.0-only"}
+authors = [
+    {name = "Luis Chumpitaz Diaz", email = "luis.chumpitazdiaz@gladstone.ucsf.edu"},
+]
+keywords = ["gaussian-processes", "spatial-transcriptomics", "variational-inference", "pytorch", "single-cell"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Science/Research",
+    "Topic :: Scientific/Engineering :: Bio-Informatics",
+    "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
+    "Programming Language :: Python :: 3",
+]
+dependencies = [
+    "torch>=1.9.0",
+    "numpy>=1.19.0",
+    "scikit-learn>=1.0.0",
+    "tqdm>=4.0.0",
+    "faiss-cpu>=1.7.0",
+    "matplotlib>=3.3.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=6.0",
+    "pytest-cov>=2.0",
+    "black>=21.0",
+    "isort>=5.0",
+]
+
+[project.urls]
+Homepage = "https://github.com/luisdiaz1997/GPzoo"
+Repository = "https://github.com/luisdiaz1997/GPzoo"
+Issues = "https://github.com/luisdiaz1997/GPzoo/issues"
+
+[tool.setuptools]
+packages = ["gpzoo"]
+
+[tool.setuptools.package-data]
+gpzoo = ["*.py"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]
+python_classes = ["Test*"]
+python_functions = ["test_*"]
+addopts = "-v"

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,11 @@
-from setuptools import setup, find_packages
+"""
+Minimal setup.py for backwards compatibility.
 
+All package metadata and dependencies are defined in pyproject.toml.
+This file exists only for tools that don't fully support PEP 517/518.
+"""
 
-setup(name='gpzoo',
-    version='0.1',
-    packages = find_packages()
-)
+from setuptools import setup
+
+# All configuration is in pyproject.toml
+setup()


### PR DESCRIPTION
## Summary

- Replace `LowRankPlusDiagonal` covariance in LCGP with VNNGP-style `S = Lu @ Lu.T` parameterization, matching the VNNGP approach for consistency and scalability
- Simplify missing-group fallback in `mggp_kmeans_inducing_points`: replace complex proportional K-means fallback with a cleaner donor-sampling strategy that keeps total inducing point count stable
- Add `pyproject.toml` for proper pip installation (`pip install git+https://github.com/luisdiaz1997/GPzoo.git`), update `setup.py` to a minimal PEP 517 stub, and add `CLAUDE.md`

## Test plan

- [ ] Install from git URL: `pip install git+https://github.com/luisdiaz1997/GPzoo.git`
- [ ] Verify `from gpzoo.gp import LCGP, MGGP_LCGP` works after install
- [ ] Run PNMF spatial tests that exercise LCGP (`tests/test_lcgp.py`)
- [ ] Verify MGGP inducing point selection handles missing groups via donor sampling